### PR TITLE
build.gradleの調整

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,43 +1,112 @@
-plugins {
-    id 'org.springframework.boot' version '2.3.9.BUILD-SNAPSHOT'
-    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-    id 'java'
-}
-
-group = 'com.pontsuyo'
-version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
-
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
+buildscript {
+    ext {
+        springBootVersion = '2.4.0'
+        wrapperVersion = '1.0.17.RELEASE'
+        shadowVersion = '5.1.0'
+    }
+    repositories {
+        mavenLocal()
+        jcenter()
+        mavenCentral()
+        maven { url "https://repo.spring.io/snapshot" }
+        maven { url "https://repo.spring.io/milestone" }
+    }
+    dependencies {
+        classpath "com.github.jengelman.gradle.plugins:shadow:${shadowVersion}"
+        classpath("org.springframework.boot.experimental:spring-boot-thin-gradle-plugin:${wrapperVersion}")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
+        classpath("io.spring.gradle:dependency-management-plugin:1.0.8.RELEASE")
     }
 }
 
+apply plugin: 'java'
+apply plugin: 'maven'
+apply plugin: 'idea'
+apply plugin: 'com.github.johnrengelman.shadow'
+apply plugin: 'org.springframework.boot'
+apply plugin: 'org.springframework.boot.experimental.thin-launcher'
+apply plugin: 'io.spring.dependency-management'
+
+group = 'com.pontsuyo'
+version = '2.0.0.RELEASE'
+sourceCompatibility = JavaVersion.VERSION_11
+
+
 repositories {
+    mavenLocal()
     mavenCentral()
-    maven { url 'https://repo.spring.io/milestone' }
-    maven { url 'https://repo.spring.io/snapshot' }
+    maven { url "https://repo.spring.io/snapshot" }
+    maven { url "https://repo.spring.io/milestone" }
 }
 
 ext {
-    set('springCloudVersion', "Hoxton.BUILD-SNAPSHOT")
+    springCloudFunctionVersion = "3.1.1"
+    awsLambdaEventsVersion = "2.0.2"
+    awsLambdaCoreVersion = "1.1.0"
+    twitter4jVersion = "4.0.7"
+}
+ext['reactor.version'] = "3.4.0"
+
+assemble.dependsOn = [shadowJar, thinJar]
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'example.Config'
+    }
 }
 
-dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
-    annotationProcessor 'org.projectlombok:lombok'
-    testImplementation('org.springframework.boot:spring-boot-starter-test') {
-        exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+
+import com.github.jengelman.gradle.plugins.shadow.transformers.PropertiesFileTransformer
+
+shadowJar {
+    classifier = 'aws'
+    dependencies {
+        exclude(
+                dependency("org.springframework.cloud:spring-cloud-function-web:${springCloudFunctionVersion}"))
     }
+    // Required for Spring
+    mergeServiceFiles()
+    append 'META-INF/spring.handlers'
+    append 'META-INF/spring.schemas'
+    append 'META-INF/spring.tooling'
+    transform(PropertiesFileTransformer) {
+        paths = ['META-INF/spring.factories']
+        mergeStrategy = "append"
+    }
+}
+
+configurations {
+    testCompile.extendsFrom(compileOnly)
 }
 
 dependencyManagement {
     imports {
-        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+        mavenBom "org.springframework.cloud:spring-cloud-function-dependencies:${springCloudFunctionVersion}"
     }
+}
+
+dependencies {
+    compile("org.springframework.cloud:spring-cloud-function-adapter-aws")
+    compile("org.springframework.cloud:spring-cloud-starter-function-webflux")
+    compileOnly("com.amazonaws:aws-lambda-java-events:${awsLambdaEventsVersion}")
+    compileOnly("com.amazonaws:aws-lambda-java-core:${awsLambdaCoreVersion}")
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+
+    testCompile('org.springframework.boot:spring-boot-starter-test')
+
+    compile("org.springframework.boot:spring-boot-starter-web")
+
+    // lombok
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+
+    // AWS SDK
+    implementation platform('software.amazon.awssdk:bom:2.15.0')
+    implementation 'software.amazon.awssdk:aws-json-protocol'
+    implementation 'software.amazon.awssdk:dynamodb'
+
+    // Twitter4J https://mvnrepository.com/artifact/org.twitter4j/twitter4j-core
+    compile group: 'org.twitter4j', name: 'twitter4j-core', version: '4.0.7'
 }
 
 test {


### PR DESCRIPTION
### 変更内容
先に開発を進めていた https://github.com/pontsuyo/tweet-analyzer-loader に合わせる。
本当は共通部分はライブラリとして切り出すのが適切そう
